### PR TITLE
Walk migration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.27.2", features = ["extension-module"] }
+walkdir = "2.5.0"
 
 [features]
 default = ["python"]

--- a/main.py
+++ b/main.py
@@ -8,12 +8,15 @@ def add_function(x: int, y: int) -> int:
     result = add_numbers(x, y)
     print(result)
     return result
-    
+
+
 def walk_dir(dir: str):
-    from the_search_thing import walk # ty:ignore[unresolved-import]
-    
-    walk("C:/Users/karth/Downloads")
+    from the_search_thing import walk  # ty:ignore[unresolved-import]
+
+    walk(dir)
 
 
 if __name__ == "__main__":
-    add_function(12, 13)
+    # add_function(12, 13)
+
+    walk_dir("C:/Users/karth/Downloads")

--- a/main.py
+++ b/main.py
@@ -8,6 +8,11 @@ def add_function(x: int, y: int) -> int:
     result = add_numbers(x, y)
     print(result)
     return result
+    
+def walk_dir(dir: str):
+    from the_search_thing import walk # ty:ignore[unresolved-import]
+    
+    walk("C:/Users/karth/Downloads")
 
 
 if __name__ == "__main__":

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,5 +6,6 @@ mod walk;
 #[pymodule]
 fn the_search_thing(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(add::add_numbers, m)?)?;
+    m.add_function(wrap_pyfunction!(walk::walk, m)?)?;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 use pyo3::prelude::*;
 
 mod add;
+mod walk;
 
 #[pymodule]
 fn the_search_thing(m: &Bound<'_, PyModule>) -> PyResult<()> {

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -1,0 +1,12 @@
+use pyo3::prelude::*;
+use walkdir::WalkDir;
+
+#[pyfunction]
+pub fn walk(dir: String) -> PyResult<()> {
+    for entry in WalkDir::new(dir) {
+        let entry =
+            entry.map_err(|e| PyErr::new::<pyo3::exceptions::PyIOError, _>(format!("{}", e)))?;
+        println!("{}", entry.path().display());
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Description
Adding rust-based walkdir function to walk.


## Checklist when merging to main

- [X] No compiler warnings (if applicable)
- [X] Code is formatted with `rustfmt`, `ty`
- [X] No useless or dead code (if applicable)
- [X] Code is easy to understand
- [X] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [X] All tests pass
- [X] Performance has not regressed (assuming change was not to fix a bug)
