### PR TITLE
bugfix search-ui shrinking post search

### DIFF
--- a/electron-react-app-main/app/components/Results.tsx
+++ b/electron-react-app-main/app/components/Results.tsx
@@ -56,10 +56,10 @@ const Results: React.FC<ResultProps> = ({ searchResults, query, hasSearched }) =
         <div className="flex w-full h-full">
           {/* Files & its paths */}
           <div className="w-1/3 min-w-[200px] max-w-[300px] h-full border-r border-zinc-700 flex flex-col">
-            <div className="p-1">
+            <div className="p-1 flex-none">
               <h3 className="text-zinc-400 text-[0.8rem] font-medium">Recently Used</h3>
             </div>
-            <div className="flex flex-col justify-center pr-2">
+            <div className="flex-1 min-h-0 flex flex-col overflow-y-auto pr-2">
               {allResults.map((result, index) => (
                 <div
                   key={`${result.path}-${result.label}-${index}`}
@@ -94,13 +94,13 @@ const Results: React.FC<ResultProps> = ({ searchResults, query, hasSearched }) =
           </div>
 
           {/* Content preview */}
-          <div className="flex-1 h-full overflow-y-auto">
+          <div className="flex-1 h-full ">
               {selectedItem ? (
-                <div className="p-4">
-                  <div className='p-5 rounded-2xl min-h-[320px] bg-zinc-900'>
-                  <div className="text-zinc-300 whitespace-pre-wrap">
-                    {selectedItem.content ?? 'No preview available for this result.'}
-                  </div>
+                <div className="p-4 h-full">
+                  <div className='p-5 rounded-2xl min-h-[320px] bg-zinc-900 overflow-hidden'>
+                    <div className="text-zinc-300 whitespace-pre-wrap overflow-y-auto max-h-[calc(100vh-200px)]">
+                      {selectedItem.content ?? 'No preview available for this result.'}
+                    </div>
                   </div>
                 </div>
             ) : (

--- a/electron-react-app-main/app/components/home/Home.tsx
+++ b/electron-react-app-main/app/components/home/Home.tsx
@@ -28,7 +28,7 @@ export default function Home() {
 
   return (
     <div className="welcome-content flex flex-col gap-5 h-screen">
-      <div className="flex items-center basis-[15%]">
+      <div className="flex items-center flex-none min-h-[55px]">
         <Searchbar
           value={query}
           onChange={(e) => {
@@ -47,8 +47,7 @@ export default function Home() {
 
       <div
         className={cn(
-          'flex',
-          'basis-[75%]',
+          'flex flex-1 min-h-0',
           'border-2 border-zinc-700/80 bg-zinc-800/60',
           'px-4 shadow-[0_0_0_1px_rgba(255,255,255,0.03)]'
         )}
@@ -58,8 +57,7 @@ export default function Home() {
 
       <div
         className={cn(
-          'flex items-center',
-          'basis-[10%]',
+          'flex items-center flex-none min-h-[56px]',
           ' bg-zinc-800/60',
           'px-4 shadow-[0_0_0_1px_rgba(255,255,255,0.03)]'
         )}


### PR DESCRIPTION
## Description
Bugfix for shrinking ui after search. Now searchbar and footer wont move and results table has a scrolling feature.

## Checklist when merging to main
- [X] No compiler warnings (if applicable)
- [X] Code is formatted with `rustfmt`, `ty`
- [X] No useless or dead code (if applicable)
- [X] Code is easy to understand
- [X] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [X] All tests pass
- [X] Performance has not regressed (assuming change was not to fix a bug)


