### PR TITLE
[OPTIMIZATION]: make search faster by parallelizing queries

### DIFF
--- a/backend/search.py
+++ b/backend/search.py
@@ -195,6 +195,7 @@ async def goated_search(search_query: str) -> dict:
         asyncio.to_thread(
             helix_client.query, "SearchImageEmbeddings", image_search_params
         ),
+        return_exceptions=True,
     )
 
     file_items: list[dict] = []

--- a/backend/search.py
+++ b/backend/search.py
@@ -173,7 +173,6 @@ async def search_images(search_query: str, limit: int = 10) -> dict:
     return {"response": helix_response, "results": results, "query": search_query}
 
 
-# async def search_file_vids_together(search_query: str) -> dict:
 async def goated_search(search_query: str) -> dict:
     file_search_params = {"search_text": search_query}
     video_search_params = {"search_text": search_query}

--- a/backend/search.py
+++ b/backend/search.py
@@ -1,4 +1,4 @@
-import asyncio
+import asyncio 
 import re
 import sys
 
@@ -198,6 +198,14 @@ async def goated_search(search_query: str) -> dict:
         return_exceptions=True,
     )
 
+    for label, result in (
+        ("file", file_search_results),
+        ("video", video_search_results),
+        ("image", image_search_results),
+    ):
+        if isinstance(result, BaseException):
+            print(f"{label} search failed: {result}")
+
     file_items: list[dict] = []
     video_items: list[dict] = []
     image_items: list[dict] = []
@@ -395,9 +403,12 @@ async def goated_search(search_query: str) -> dict:
         image_items.clear()
         image_items.extend(deduped)
 
-    normalize_file_results(file_search_results)
-    normalize_video_results(video_search_results)
-    normalize_image_results(image_search_results)
+    if not isinstance(file_search_results, BaseException):
+        normalize_file_results(file_search_results)
+    if not isinstance(video_search_results, BaseException):
+        normalize_video_results(video_search_results)
+    if not isinstance(image_search_results, BaseException):
+        normalize_image_results(image_search_results)
 
     keywords = re.findall(r"\w+", search_query.lower())
 

--- a/backend/search.py
+++ b/backend/search.py
@@ -178,6 +178,24 @@ async def goated_search(search_query: str) -> dict:
     file_search_params = {"search_text": search_query}
     video_search_params = {"search_text": search_query}
     image_search_params = {"search_text": search_query}
+    helix_client = get_helix_client()
+
+    (
+        file_search_results,
+        video_search_results,
+        image_search_results,
+    ) = await asyncio.gather(
+        asyncio.to_thread(
+            helix_client.query, "SearchFileEmbeddings", file_search_params
+        ),
+        asyncio.to_thread(
+            helix_client.query,
+            "SearchTranscriptAndFrameEmbeddings",
+            video_search_params,
+        ),
+        asyncio.to_thread(
+            helix_client.query, "SearchImageEmbeddings", image_search_params
+        ),
     )
 
     file_items: list[dict] = []

--- a/backend/search.py
+++ b/backend/search.py
@@ -176,18 +176,8 @@ async def search_images(search_query: str, limit: int = 10) -> dict:
 # async def search_file_vids_together(search_query: str) -> dict:
 async def goated_search(search_query: str) -> dict:
     file_search_params = {"search_text": search_query}
-    file_search_results = get_helix_client().query(
-        "SearchFileEmbeddings", file_search_params
-    )
-
     video_search_params = {"search_text": search_query}
-    video_search_results = get_helix_client().query(
-        "SearchTranscriptAndFrameEmbeddings", video_search_params
-    )
-
     image_search_params = {"search_text": search_query}
-    image_search_results = get_helix_client().query(
-        "SearchImageEmbeddings", image_search_params
     )
 
     file_items: list[dict] = []


### PR DESCRIPTION
## Description
uses `asyncio.gather` and `asyncion.to_thread` to run them concurrently so theres not sequential block on the async function

## Checklist when merging to main

- [x] No compiler warnings (if applicable)
- [x] Code is formatted with `rustfmt`, `ty`
- [x] No useless or dead code (if applicable)
- [x] Code is easy to understand
- [x] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [x] All tests pass
- [x] Performance has not regressed (assuming change was not to fix a bug)

