### PR TITLE
[FIX] Adding shared indexing states between footer and results.

### DIFF
--- a/client/app/AppContext.tsx
+++ b/client/app/AppContext.tsx
@@ -3,15 +3,33 @@ import { createContext, useContext, useState, ReactNode } from 'react'
 interface AppContextType {
   isIndexed: boolean
   setIsIndexed: (value: boolean) => void
+  awaitingIndexing: boolean
+  setAwaitingIndexing: (value: boolean) => void
+  currentJobId: string | null
+  setCurrentJobId: (id: string | null) => void
+  indexingLocation: 'results' | 'footer' | null
+  setIndexingLocation: (loc: 'results' | 'footer' | null) => void
+  dirIndexed: string | null
+  setDirIndexed: (dir: string | null) => void
 }
 
 const AppContext = createContext<AppContextType | undefined>(undefined)
 
 export const AppProvider = ({ children }: { children: ReactNode }) => {
   const [isIndexed, setIsIndexed] = useState(false)
+  const [awaitingIndexing, setAwaitingIndexing] = useState(false)
+  const [currentJobId, setCurrentJobId] = useState<string | null>(null)
+  const [indexingLocation, setIndexingLocation] = useState<'results' | 'footer' | null>(null)
+  const [dirIndexed, setDirIndexed] = useState<string | null>(null)
 
   return (
-      <AppContext.Provider value={{ isIndexed, setIsIndexed }}>
+    <AppContext.Provider value={{
+      isIndexed, setIsIndexed,
+      awaitingIndexing, setAwaitingIndexing,
+      currentJobId, setCurrentJobId,
+      indexingLocation, setIndexingLocation,
+      dirIndexed, setDirIndexed
+    }}>
         {children}
       </AppContext.Provider>
     )

--- a/client/app/AppContext.tsx
+++ b/client/app/AppContext.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, useState, ReactNode } from 'react'
+import { IndexJobStatus } from './types/types'
 
 interface AppContextType {
   isIndexed: boolean
@@ -11,6 +12,8 @@ interface AppContextType {
   setIndexingLocation: (loc: 'results' | 'footer' | null) => void
   dirIndexed: string | null
   setDirIndexed: (dir: string | null) => void
+  jobStatus: IndexJobStatus | null
+  setJobStatus: (status: IndexJobStatus | null) => void
 }
 
 const AppContext = createContext<AppContextType | undefined>(undefined)
@@ -21,6 +24,7 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
   const [currentJobId, setCurrentJobId] = useState<string | null>(null)
   const [indexingLocation, setIndexingLocation] = useState<'results' | 'footer' | null>(null)
   const [dirIndexed, setDirIndexed] = useState<string | null>(null)
+  const [jobStatus, setJobStatus] = useState<IndexJobStatus | null>(null)
 
   return (
     <AppContext.Provider value={{
@@ -28,7 +32,8 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
       awaitingIndexing, setAwaitingIndexing,
       currentJobId, setCurrentJobId,
       indexingLocation, setIndexingLocation,
-      dirIndexed, setDirIndexed
+      dirIndexed, setDirIndexed,
+      jobStatus, setJobStatus
     }}>
         {children}
       </AppContext.Provider>

--- a/client/app/components/Footer.tsx
+++ b/client/app/components/Footer.tsx
@@ -21,16 +21,16 @@ export default function Footer() {
   const [errorMessage, setErrorMessage] = useState('')
   const [isPopoverOpen, setIsPopoverOpen] = useState(false)
   const popoverRef = useRef<HTMLDivElement>(null)
-  
-  const { 
-    currentJobId, 
-    setCurrentJobId, 
-    indexingLocation, 
+
+  const {
+    currentJobId,
+    setCurrentJobId,
+    indexingLocation,
     setIndexingLocation,
     setDirIndexed,
-    dirIndexed,
     jobStatus,
-    setJobStatus
+    setJobStatus,
+    setAwaitingIndexing,
   } = useAppContext()
 
   // Close popover when clicking outside
@@ -50,7 +50,7 @@ export default function Footer() {
     }
   }, [isPopoverOpen])
 
-  // Poll job status every 2 seconds 
+  // Poll job status every 2 seconds
   useEffect(() => {
     if (!currentJobId) {
       setJobStatus(null)
@@ -65,15 +65,15 @@ export default function Footer() {
         setJobStatus(status)
         if (status.status === 'completed' || status.status === 'failed') {
           clearInterval(intervalId)
-          // Clear job state after completion
-          if (status.status === 'completed') {
-            setTimeout(() => {
-              setCurrentJobId(null)
-              setIndexingLocation(null)
-              setDirIndexed(null)
-              setJobStatus(null)
-            }, 3000)
-          }
+          // Clear job state after completion or failure
+          const delay = status.status === 'completed' ? 3000 : 5000
+          setTimeout(() => {
+            setCurrentJobId(null)
+            setIndexingLocation(null)
+            setDirIndexed(null)
+            setJobStatus(null)
+            setAwaitingIndexing(false)
+          }, delay)
         }
       } catch (error) {
         console.error('Error fetching index status:', error)
@@ -86,7 +86,7 @@ export default function Footer() {
       isActive = false
       clearInterval(intervalId)
     }
-  }, [currentJobId, search, setCurrentJobId, setIndexingLocation, setDirIndexed, setJobStatus])
+  }, [currentJobId, search, setCurrentJobId, setIndexingLocation, setDirIndexed, setJobStatus, setAwaitingIndexing])
 
   const handleStartIndexing = async () => {
     const res = await search.openFileDialog()

--- a/client/app/components/Footer.tsx
+++ b/client/app/components/Footer.tsx
@@ -58,6 +58,7 @@ export default function Footer() {
     }
 
     let isActive = true
+    let timeoutId: ReturnType<typeof setTimeout> | null = null
     const fetchStatus = async () => {
       try {
         const status = await search.indexStatus(currentJobId)
@@ -67,7 +68,8 @@ export default function Footer() {
           clearInterval(intervalId)
           // Clear job state after completion or failure
           const delay = status.status === 'completed' ? 3000 : 5000
-          setTimeout(() => {
+          timeoutId = setTimeout(() => {
+            if (!isActive) return
             setCurrentJobId(null)
             setIndexingLocation(null)
             setDirIndexed(null)
@@ -85,6 +87,9 @@ export default function Footer() {
     return () => {
       isActive = false
       clearInterval(intervalId)
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId)
+      }
     }
   }, [currentJobId, search, setCurrentJobId, setIndexingLocation, setDirIndexed, setJobStatus, setAwaitingIndexing])
 

--- a/client/app/components/Footer.tsx
+++ b/client/app/components/Footer.tsx
@@ -3,7 +3,6 @@ import { useConveyor } from '../hooks/use-conveyor'
 import { Button } from './ui/button'
 import about from '@/resources/about.svg'
 import enter from '@/resources/enter.svg'
-import { IndexJobStatus } from '../types/types'
 import { useAppContext } from '../AppContext'
 
 const phaseLabels: Record<string, string> = {
@@ -21,7 +20,6 @@ export default function Footer() {
   const [isIndexing, setIsIndexing] = useState(false)
   const [errorMessage, setErrorMessage] = useState('')
   const [isPopoverOpen, setIsPopoverOpen] = useState(false)
-  const [jobStatus, setJobStatus] = useState<IndexJobStatus | null>(null)
   const popoverRef = useRef<HTMLDivElement>(null)
   
   const { 
@@ -30,7 +28,9 @@ export default function Footer() {
     indexingLocation, 
     setIndexingLocation,
     setDirIndexed,
-    dirIndexed
+    dirIndexed,
+    jobStatus,
+    setJobStatus
   } = useAppContext()
 
   // Close popover when clicking outside
@@ -71,6 +71,7 @@ export default function Footer() {
               setCurrentJobId(null)
               setIndexingLocation(null)
               setDirIndexed(null)
+              setJobStatus(null)
             }, 3000)
           }
         }
@@ -85,7 +86,7 @@ export default function Footer() {
       isActive = false
       clearInterval(intervalId)
     }
-  }, [currentJobId, search, setCurrentJobId, setIndexingLocation, setDirIndexed])
+  }, [currentJobId, search, setCurrentJobId, setIndexingLocation, setDirIndexed, setJobStatus])
 
   const handleStartIndexing = async () => {
     const res = await search.openFileDialog()

--- a/client/app/components/Results.tsx
+++ b/client/app/components/Results.tsx
@@ -36,7 +36,8 @@ const Results: React.FC<ResultsWithContextProps> = ({ searchResults, query, hasS
     setIndexingLocation,
     dirIndexed,
     setDirIndexed,
-    setAwaitingIndexing
+    setAwaitingIndexing,
+    jobStatus
   } = useAppContext()
 
   const allResults = searchResults?.results || []
@@ -136,18 +137,55 @@ const Results: React.FC<ResultsWithContextProps> = ({ searchResults, query, hasS
             <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
           </svg>
           <div className="text-zinc-200 text-lg font-medium">
-            Indexing in progress...
+            {jobStatus ? phaseLabels[jobStatus.phase] || jobStatus.phase : 'Starting indexing...'}
           </div>
         </div>
 
         {currentJobId && dirIndexed && <div className="text-zinc-500 text-xs font-mono">Directory: {dirIndexed}</div>}
+        
+        {jobStatus && (
+          <div className="flex flex-col gap-3 w-full max-w-sm">
+            {progressSection(
+              'Text files',
+              jobStatus.text_found,
+              jobStatus.text_indexed,
+              jobStatus.text_errors,
+              jobStatus.text_skipped
+            )}
+            {progressSection(
+              'Videos',
+              jobStatus.video_found,
+              jobStatus.video_indexed,
+              jobStatus.video_errors,
+              jobStatus.video_skipped
+            )}
+            {progressSection(
+              'Images',
+              jobStatus.image_found,
+              jobStatus.image_indexed,
+              jobStatus.image_errors,
+              jobStatus.image_skipped
+            )}
 
-        {/* Progress indicator - simplified since Footer has the actual polling */}
-        <div className="flex flex-col gap-3 w-full max-w-sm">
-          <div className="text-zinc-400 text-sm text-center">
-            Check the footer for detailed progress
+            {/* Status message */}
+            {jobStatus.message && <div className="text-zinc-400 text-xs text-center mt-1">{jobStatus.message}</div>}
+
+            {/* Error */}
+            {jobStatus.error && (
+              <div className="text-red-400 text-xs text-center mt-1 bg-red-950/30 rounded px-3 py-2">
+                {jobStatus.error}
+              </div>
+            )}
+
+            {/* Completed / failed badge */}
+            {jobStatus.status === 'completed' && (
+              <div className="text-green-400 text-sm text-center mt-2 font-medium">Indexing complete!</div>
+            )}
+            {jobStatus.status === 'failed' && (
+              <div className="text-red-400 text-sm text-center mt-2 font-medium">Indexing failed</div>
+            )}
           </div>
-        </div>
+        )}
       </div>
     )
   }

--- a/client/app/components/Results.tsx
+++ b/client/app/components/Results.tsx
@@ -1,25 +1,43 @@
 import * as React from 'react'
 import { useState, useEffect, useRef, useCallback } from 'react'
 import noFiles from '@/resources/no-files-found.svg'
-import { ResultProps, SearchResultItem, IndexJobStatus } from '../types/types'
+import { ResultProps, SearchResultItem } from '../types/types'
 import * as fileIcons from '@/resources/filetype icons'
 import { useConveyor } from '../hooks/use-conveyor'
+import { useAppContext } from '../AppContext'
 
 type ResultItem = SearchResultItem
 
-const Results: React.FC<
-  ResultProps & {
-    currentJobId: string | null
-    setCurrentJobId: (jobId: string | null) => void
-    onIndexingCancelled?: () => void
-  }
-> = ({ searchResults, query, hasSearched, awaitingIndexing, currentJobId, setCurrentJobId, onIndexingCancelled }) => {
+const phaseLabels: Record<string, string> = {
+  scan_text: 'Scanning text files',
+  index_text: 'Indexing text files',
+  scan_video: 'Scanning videos',
+  index_video: 'Indexing videos',
+  scan_image: 'Scanning images',
+  index_image: 'Indexing images',
+  done: 'Done',
+}
+
+interface ResultsWithContextProps extends ResultProps {
+  onIndexingCancelled?: () => void
+}
+
+const Results: React.FC<ResultsWithContextProps> = ({ searchResults, query, hasSearched, onIndexingCancelled }) => {
   const [selectedItem, setSelectedItem] = useState<ResultItem | null>(null)
-  const [jobStatus, setJobStatus] = useState<IndexJobStatus | null>(null)
-  const [dirIndexed, setDirIndexed] = useState<string | null>(null)
   const [hasInitiatedIndexing, setHasInitiatedIndexing] = useState(false)
   const hasOpenedDialogRef = useRef(false)
   const search = useConveyor('search')
+  
+  const {
+    awaitingIndexing, 
+    currentJobId,
+    setCurrentJobId,
+    indexingLocation,
+    setIndexingLocation,
+    dirIndexed,
+    setDirIndexed,
+    setAwaitingIndexing
+  } = useAppContext()
 
   const allResults = searchResults?.results || []
 
@@ -30,40 +48,9 @@ const Results: React.FC<
   useEffect(() => {
     if (!hasSearched) {
       setHasInitiatedIndexing(false)
-      setCurrentJobId(null)
-
-      setJobStatus(null)
       hasOpenedDialogRef.current = false
     }
-  }, [hasSearched, query, setCurrentJobId])
-
-  useEffect(() => {
-    if (!currentJobId) {
-      setJobStatus(null)
-      return
-    }
-
-    let isActive = true
-    const fetchStatus = async () => {
-      try {
-        const status = await search.indexStatus(currentJobId)
-        if (!isActive) return
-        setJobStatus(status)
-        if (status.status === 'completed' || status.status === 'failed') {
-          clearInterval(intervalId)
-        }
-      } catch (error) {
-        console.error('Error fetching index status:', error)
-      }
-    }
-
-    fetchStatus()
-    const intervalId = window.setInterval(fetchStatus, 1500)
-    return () => {
-      isActive = false
-      clearInterval(intervalId)
-    }
-  }, [currentJobId, search])
+  }, [hasSearched, query])
 
   const handleOpen = (filePath: string) => {
     search.openFile(filePath)
@@ -85,6 +72,7 @@ const Results: React.FC<
     if (!res || res.length === 0) {
       // User cancelled the file dialog - reset the awaiting state
       onIndexingCancelled?.()
+      setAwaitingIndexing(false)
       setHasInitiatedIndexing(false)
       hasOpenedDialogRef.current = false
       return
@@ -97,11 +85,12 @@ const Results: React.FC<
       console.error('Index response:', indexRes)
       if (indexRes.success && indexRes.job_id) {
         setCurrentJobId(indexRes.job_id)
+        setIndexingLocation('results')
       }
     } catch (error) {
       console.error('Error indexing files:', error)
     }
-  }, [search, onIndexingCancelled, setCurrentJobId])
+  }, [search, onIndexingCancelled, setCurrentJobId, setIndexingLocation, setDirIndexed, setAwaitingIndexing])
 
   useEffect(() => {
     if (awaitingIndexing && !currentJobId && !hasInitiatedIndexing && !hasOpenedDialogRef.current) {
@@ -112,102 +101,53 @@ const Results: React.FC<
     }
   }, [awaitingIndexing, currentJobId, hasInitiatedIndexing, handleStartIndexing])
 
-  if (awaitingIndexing) {
-    const phaseLabels: Record<string, string> = {
-      scan_text: 'Scanning text files',
-      index_text: 'Indexing text files',
-      scan_video: 'Scanning videos',
-      index_video: 'Indexing videos',
-      scan_image: 'Scanning images',
-      index_image: 'Indexing images',
-      done: 'Done',
-    }
-
-    const progressSection = (label: string, found: number, indexed: number, errors: number, skipped: number) => {
-      const total = found || 1
-      const pct = found > 0 ? Math.round((indexed / total) * 100) : 0
-      if (found === 0 && indexed === 0) return null
-      return (
-        <div className="w-full">
-          <div className="flex justify-between text-xs text-zinc-400 mb-1">
-            <span>{label}</span>
-            <span>
-              {indexed}/{found}
-              {errors > 0 && <span className="text-red-400 ml-1">({errors} errors)</span>}
-              {skipped > 0 && <span className="text-yellow-400 ml-1">({skipped} skipped)</span>}
-            </span>
-          </div>
-          <div className="w-full h-1.5 bg-zinc-700 rounded-full overflow-hidden">
-            <div
-              className="h-full bg-blue-500 rounded-full transition-all duration-500 ease-out"
-              style={{ width: `${pct}%` }}
-            />
-          </div>
+  const progressSection = (label: string, found: number, indexed: number, errors: number, skipped: number) => {
+    const total = found || 1
+    const pct = found > 0 ? Math.round((indexed / total) * 100) : 0
+    if (found === 0 && indexed === 0) return null
+    return (
+      <div className="w-full">
+        <div className="flex justify-between text-xs text-zinc-400 mb-1">
+          <span>{label}</span>
+          <span>
+            {indexed}/{found}
+            {errors > 0 && <span className="text-red-400 ml-1">({errors} errors)</span>}
+            {skipped > 0 && <span className="text-yellow-400 ml-1">({skipped} skipped)</span>}
+          </span>
         </div>
-      )
-    }
+        <div className="w-full h-1.5 bg-zinc-700 rounded-full overflow-hidden">
+          <div
+            className="h-full bg-blue-500 rounded-full transition-all duration-500 ease-out"
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+      </div>
+    )
+  }
 
+  // Show full indexing UI when actively indexing in results view
+  if (indexingLocation === 'results' && awaitingIndexing) {
     return (
       <div className="flex flex-col w-full h-full items-center justify-center p-6 gap-5">
         {/* Spinner + phase label */}
         <div className="flex items-center gap-3">
-          {(!jobStatus || jobStatus.status === 'running') && (
-            <svg className="animate-spin h-5 w-5 text-blue-400" viewBox="0 0 24 24" fill="none">
-              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-            </svg>
-          )}
+          <svg className="animate-spin h-5 w-5 text-blue-400" viewBox="0 0 24 24" fill="none">
+            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+          </svg>
           <div className="text-zinc-200 text-lg font-medium">
-            {jobStatus ? phaseLabels[jobStatus.phase] || jobStatus.phase : 'Starting indexing…'}
+            Indexing in progress...
           </div>
         </div>
 
         {currentJobId && dirIndexed && <div className="text-zinc-500 text-xs font-mono">Directory: {dirIndexed}</div>}
 
-        {/* Progress bars */}
-        {jobStatus && (
-          <div className="flex flex-col gap-3 w-full max-w-sm">
-            {progressSection(
-              'Text files',
-              jobStatus.text_found,
-              jobStatus.text_indexed,
-              jobStatus.text_errors,
-              jobStatus.text_skipped
-            )}
-            {progressSection(
-              'Videos',
-              jobStatus.video_found,
-              jobStatus.video_indexed,
-              jobStatus.video_errors,
-              jobStatus.video_skipped
-            )}
-            {progressSection(
-              'Images',
-              jobStatus.image_found,
-              jobStatus.image_indexed,
-              jobStatus.image_errors,
-              jobStatus.image_skipped
-            )}
-
-            {/* Status message */}
-            {jobStatus.message && <div className="text-zinc-400 text-xs text-center mt-1">{jobStatus.message}</div>}
-
-            {/* Error */}
-            {jobStatus.error && (
-              <div className="text-red-400 text-xs text-center mt-1 bg-red-950/30 rounded px-3 py-2">
-                {jobStatus.error}
-              </div>
-            )}
-
-            {/* Completed / failed badge */}
-            {jobStatus.status === 'completed' && (
-              <div className="text-green-400 text-sm text-center mt-2 font-medium">Indexing complete!</div>
-            )}
-            {jobStatus.status === 'failed' && (
-              <div className="text-red-400 text-sm text-center mt-2 font-medium">Indexing failed</div>
-            )}
+        {/* Progress indicator - simplified since Footer has the actual polling */}
+        <div className="flex flex-col gap-3 w-full max-w-sm">
+          <div className="text-zinc-400 text-sm text-center">
+            Check the footer for detailed progress
           </div>
-        )}
+        </div>
       </div>
     )
   }

--- a/client/app/components/Results.tsx
+++ b/client/app/components/Results.tsx
@@ -27,9 +27,9 @@ const Results: React.FC<ResultsWithContextProps> = ({ searchResults, query, hasS
   const [hasInitiatedIndexing, setHasInitiatedIndexing] = useState(false)
   const hasOpenedDialogRef = useRef(false)
   const search = useConveyor('search')
-  
+
   const {
-    awaitingIndexing, 
+    awaitingIndexing,
     currentJobId,
     setCurrentJobId,
     indexingLocation,
@@ -37,7 +37,7 @@ const Results: React.FC<ResultsWithContextProps> = ({ searchResults, query, hasS
     dirIndexed,
     setDirIndexed,
     setAwaitingIndexing,
-    jobStatus
+    jobStatus,
   } = useAppContext()
 
   const allResults = searchResults?.results || []
@@ -79,8 +79,7 @@ const Results: React.FC<ResultsWithContextProps> = ({ searchResults, query, hasS
       return
     }
 
-    const filename = getFileName(res)
-    setDirIndexed(filename)
+    setDirIndexed(res)
     try {
       const indexRes = await search.index(res)
       console.error('Index response:', indexRes)
@@ -132,17 +131,19 @@ const Results: React.FC<ResultsWithContextProps> = ({ searchResults, query, hasS
       <div className="flex flex-col w-full h-full items-center justify-center p-6 gap-5">
         {/* Spinner + phase label */}
         <div className="flex items-center gap-3">
-          <svg className="animate-spin h-5 w-5 text-blue-400" viewBox="0 0 24 24" fill="none">
-            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-          </svg>
+          {(!jobStatus || (jobStatus.status !== 'completed' && jobStatus.status !== 'failed')) && (
+            <svg className="animate-spin h-5 w-5 text-blue-400" viewBox="0 0 24 24" fill="none">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+            </svg>
+          )}
           <div className="text-zinc-200 text-lg font-medium">
             {jobStatus ? phaseLabels[jobStatus.phase] || jobStatus.phase : 'Starting indexing...'}
           </div>
         </div>
 
         {currentJobId && dirIndexed && <div className="text-zinc-500 text-xs font-mono">Directory: {dirIndexed}</div>}
-        
+
         {jobStatus && (
           <div className="flex flex-col gap-3 w-full max-w-sm">
             {progressSection(

--- a/client/app/home/Home.tsx
+++ b/client/app/home/Home.tsx
@@ -6,6 +6,7 @@ import './styles.css'
 import Results from '../components/Results'
 import Footer from '../components/Footer'
 import { SearchResponse } from '../types/types'
+import { useAppContext } from '../AppContext'
 
 export default function Home() {
   const [query, setQuery] = useState('')
@@ -13,9 +14,14 @@ export default function Home() {
   const [searchResults, setSearchResults] = useState<SearchResponse>()
   const [hasSearched, setHasSearched] = useState(false) //temporary logic (pls remove in the future :pray:)
   const [isLoading, setIsLoading] = useState(false)
-  const [awaitingIndexing, setAwaitingIndexing] = useState(false)
+  const { 
+    awaitingIndexing, 
+    setAwaitingIndexing,
+    currentJobId,
+    setIndexingLocation,
+    indexingLocation
+  } = useAppContext()
   const [hasInteracted, setHasInteracted] = useState(false)
-  const [currentJobId, setCurrentJobId] = useState<string | null>(null)
 
   const handleSearch = async () => {
     const lastResultsEmpty = (searchResults?.results?.length ?? 0) === 0
@@ -44,10 +50,17 @@ export default function Home() {
         <Searchbar
           value={query}
           onChange={(e) => {
-            setQuery(e.target.value)
+            const newQuery = e.target.value
+            setQuery(newQuery)
             setHasSearched(false)
             setAwaitingIndexing(false)
             setHasInteracted(true)
+            
+            // If user starts typing a new query and there's an active indexing job in results,
+            // move it to the footer
+            if (currentJobId && indexingLocation === 'results' && newQuery.length > 0) {
+              setIndexingLocation('footer')
+            }
           }}
           placeholder="Search for files or folders…"
           onKeyDown={(e) => {
@@ -74,9 +87,6 @@ export default function Home() {
               searchResults={searchResults}
               query={query}
               hasSearched={hasSearched}
-              awaitingIndexing={awaitingIndexing}
-              currentJobId={currentJobId}
-              setCurrentJobId={setCurrentJobId}
               onIndexingCancelled={() => setAwaitingIndexing(false)}
             />
           )}

--- a/client/app/types/types.ts
+++ b/client/app/types/types.ts
@@ -12,7 +12,6 @@ export interface ResultProps {
   searchResults?: SearchResponse
   query: string
   hasSearched: boolean
-  awaitingIndexing?: boolean
 }
 
 export type IndexJobStatus = {


### PR DESCRIPTION
## Description
Massive changes to the indexing logic:
- All indexing polling lives in footer since its mounted
- Results uses the states from appcontext (shared context) to display a more detailed ui if indexing from results
- Location mapping set for results and footer.

Closes #34 

## Checklist when merging to main

- [X] No compiler warnings (if applicable)
- [X] Code is formatted with `rustfmt`, `ty`
- [X] No useless or dead code (if applicable)
- [X] Code is easy to understand
- [X] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [X] All tests pass
- [X] Performance has not regressed (assuming change was not to fix a bug)