### PR TITLE
[FEATURE]: add video thumbnail on icons and preview pane

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,6 @@ node_modules/
 
 .ruff_cache/
 videos/output_indexer/
+videos/thumbnails/
 
 lazygit

--- a/backend/search.py
+++ b/backend/search.py
@@ -2,7 +2,6 @@ import asyncio
 import os
 import re
 import sys
-from pathlib import Path
 
 from dotenv import load_dotenv
 
@@ -12,6 +11,7 @@ from backend.services.search import (
     build_chunk_to_video_map,
 )
 from backend.utils.clients import get_helix_client
+from backend.services.thumbnails_cache import has_thumbnail
 
 load_dotenv()
 
@@ -465,8 +465,6 @@ async def goated_search(search_query: str) -> dict:
         seen.add(key)
         deduped.append(item)
 
-    repo_root = Path(__file__).resolve().parents[1]
-    thumbnails_dir = repo_root / "videos" / "thumbnails"
     backend_origin = os.getenv("BACKEND_ORIGIN", "http://localhost:8000")
 
     for item in deduped:
@@ -474,8 +472,7 @@ async def goated_search(search_query: str) -> dict:
             continue
         content_hash = item.get("content_hash")
         if isinstance(content_hash, str) and content_hash:
-            thumb_path = thumbnails_dir / f"{content_hash}.jpg"
-            if thumb_path.exists():
+            if has_thumbnail(content_hash):
                 item["thumbnail_url"] = f"{backend_origin}/api/thumbnails/{content_hash}"
 
     return {

--- a/backend/services/search.py
+++ b/backend/services/search.py
@@ -55,3 +55,4 @@ def _build_video_to_path_map(videos: list) -> dict[str, str]:
         if video_id and path:
             video_to_path[video_id] = path
     return video_to_path
+

--- a/backend/services/thumbnails_cache.py
+++ b/backend/services/thumbnails_cache.py
@@ -1,0 +1,35 @@
+import re
+from pathlib import Path
+
+THUMBNAIL_HASHES: set[str] = set()
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+THUMBNAILS_DIR = REPO_ROOT / "videos" / "thumbnails"
+
+_HASH_RE = re.compile(r"^[a-fA-F0-9]{64}$")
+
+
+def load_thumbnail_cache() -> None:
+    THUMBNAIL_HASHES.clear()
+    if not THUMBNAILS_DIR.exists():
+        return
+    for entry in THUMBNAILS_DIR.iterdir():
+        if not entry.is_file():
+            continue
+        if entry.suffix.lower() != ".jpg":
+            continue
+        stem = entry.stem
+        if _HASH_RE.fullmatch(stem):
+            THUMBNAIL_HASHES.add(stem)
+
+
+def has_thumbnail(content_hash: str) -> bool:
+    return content_hash in THUMBNAIL_HASHES
+
+
+def add_thumbnail(content_hash: str) -> None:
+    if _HASH_RE.fullmatch(content_hash):
+        THUMBNAIL_HASHES.add(content_hash)
+
+
+load_thumbnail_cache()

--- a/client/app/components/Results.tsx
+++ b/client/app/components/Results.tsx
@@ -254,7 +254,20 @@ const Results: React.FC<
                 }`}
               >
                 <div className="pr-2">
-                  <img src={fileIcons[getFileExt(result.path).toLowerCase()] || fileIcons.txt} className="w-5 h-5" />
+                  {result.label === 'video' && result.thumbnail_url ? (
+                    <img
+                      src={result.thumbnail_url}
+                      alt=""
+                      className="w-7 h-7 rounded-md object-cover"
+                      loading="lazy"
+                    />
+                  ) : (
+                    <img
+                      src={fileIcons[getFileExt(result.path).toLowerCase()] || fileIcons.txt}
+                      className="w-5 h-5"
+                      alt=""
+                    />
+                  )}
                 </div>
                 <div className="text-white truncate" title={result.path}>
                   {getFileName(result.path)}
@@ -268,11 +281,24 @@ const Results: React.FC<
         <div className="flex-1 h-full ">
           {selectedItem ? (
             <div className="p-4 h-full">
-              <div className="p-5 rounded-2xl min-h-[320px] bg-zinc-900 overflow-hidden">
-                <div className="text-zinc-300 whitespace-pre-wrap overflow-y-auto max-h-[calc(100vh-200px)]">
-                  {selectedItem.content ?? 'No preview available for this result.'}
+              {selectedItem.label === 'video' && selectedItem.thumbnail_url ? (
+                <div className="p-5 rounded-2xl min-h-[320px] bg-zinc-900 overflow-hidden">
+                  <img
+                    src={selectedItem.thumbnail_url}
+                    alt=""
+                    className="w-full max-h-[360px] object-contain rounded-xl bg-zinc-950"
+                  />
+                  <div className="text-zinc-400 text-xs mt-3 truncate" title={selectedItem.path}>
+                    {selectedItem.path}
+                  </div>
                 </div>
-              </div>
+              ) : (
+                <div className="p-5 rounded-2xl min-h-[320px] bg-zinc-900 overflow-hidden">
+                  <div className="text-zinc-300 whitespace-pre-wrap overflow-y-auto max-h-[calc(100vh-200px)]">
+                    {selectedItem.content ?? 'No preview available for this result.'}
+                  </div>
+                </div>
+              )}
             </div>
           ) : (
             <div className="flex items-center justify-center h-full text-zinc-500">

--- a/client/app/index.html
+++ b/client/app/index.html
@@ -5,7 +5,7 @@
     <title>Electron</title>
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: res:;"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: res: http://localhost:8000 http://127.0.0.1:8000;"
     />
   </head>
 

--- a/client/app/types/types.ts
+++ b/client/app/types/types.ts
@@ -2,6 +2,7 @@ export interface SearchResultItem {
   label: string
   content?: string | null
   path: string
+  thumbnail_url?: string | null
 }
 
 export interface SearchResponse {

--- a/client/lib/conveyor/schemas/search-schema.ts
+++ b/client/lib/conveyor/schemas/search-schema.ts
@@ -40,6 +40,7 @@ export const searchIpcSchema = {
           label: z.string(),
           content: z.string().nullable().optional(),
           path: z.string(),
+          thumbnail_url: z.string().nullable().optional(),
         })
       ),
     }),

--- a/db/schema.hx
+++ b/db/schema.hx
@@ -19,7 +19,6 @@ N::Image {
 N::Video {
     INDEX video_id: String,
     INDEX content_hash: String,
-
     no_of_chunks: U8,
     path: String
 }


### PR DESCRIPTION
## Description
this pr uses the video indexer functionality and picks the middle thumbnail generated during video indexing and uses it to copy it over as cache using the `content_hash` field. if cache file is missing it uses the icons as fallback. we use `content_hash` to locate the thumbnail_url to render in the UI

Closes #23 

## Checklist when merging to main
<!-- Mark items with "x" when completed -->

- [x] No compiler warnings (if applicable)
- [x] Code is formatted with `rustfmt`, `ty`
- [x] No useless or dead code (if applicable)
- [x] Code is easy to understand
- [x] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [x] All tests pass
- [x] Performance has not regressed (assuming change was not to fix a bug)

